### PR TITLE
Remove access to About page

### DIFF
--- a/content/pages/about/index.mdx
+++ b/content/pages/about/index.mdx
@@ -2,9 +2,3 @@
 title: About
 slug: "/about"
 ---
-
-Hi!
-
-Remus Lupin - also known as Moony - is currently teaching "Defense against the Dark Arts" at Hogwarts. He was afflicted with lycanthropy during his childhood, as a result of Fenrir Greyback's revenge against Lyall. He attended Hogwarts School of Witchcraft and Wizardry from 1971-1978 and was Sorted into Gryffindor House. During his school years he was one of the Marauders, best friends with Sirius Black, James Potter, and Peter Pettigrew. Together they created the Marauder's Map.
-
-He fought against Death Eaters once more in the Second Wizarding War, during which he lost his friend Sirius. In 1997, Remus married fellow Order member Nymphadora Tonks and had a son, Edward Remus Lupin, of whom he named Harry the godfather. Remus fought at the Battle of Hogwarts on 2 May, 1998, during which his wife was murdered by Bellatrix Lestrange. Remus was also murdered by Death Eater, Antonin Dolohov, during the first half of the same battle. His death was avenged by Filius Flitwick.

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -22,10 +22,6 @@ module.exports = {
             title: `Case Studies`,
             slug: `/blog`,
           },
-          {
-            title: `About`,
-            slug: `/about`,
-          },
         ],
         externalLinks: [
           {


### PR DESCRIPTION
- Remove reference to About from the site config
- Blank out About page text